### PR TITLE
Add return types for `jsonSerialize()`

### DIFF
--- a/ModularContent/AdminPreCache.php
+++ b/ModularContent/AdminPreCache.php
@@ -63,10 +63,10 @@ class AdminPreCache implements \JsonSerializable {
 	 * Specify data which should be serialized to JSON
 	 *
 	 * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-	 * @return mixed data which can be serialized by <b>json_encode</b>,
+	 * @return array data which can be serialized by <b>json_encode</b>,
 	 * which is a value of any type other than a resource.
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return $this->get_cache();
 	}
 

--- a/ModularContent/Blueprint_Builder.php
+++ b/ModularContent/Blueprint_Builder.php
@@ -97,7 +97,12 @@ class Blueprint_Builder implements \JsonSerializable {
 		return $children;
 	}
 
-	public function jsonSerialize() {
+	/**
+	 * Specify data which should be serialized to JSON.
+	 *
+	 * @return array Always return an array.
+	 */
+	public function jsonSerialize(): array {
 		$type = $this->get_current_post_type();
 		$blueprint = $this->get_blueprint( $type );
 		foreach ( $blueprint[ 'types' ] as $index => $panel ) {

--- a/ModularContent/Panel.php
+++ b/ModularContent/Panel.php
@@ -110,7 +110,12 @@ class Panel implements \JsonSerializable {
 		return $this->children;
 	}
 
-	public function jsonSerialize() {
+	/**
+	 * Specify data which should be serialized to JSON.
+	 *
+	 * @return array Always return an array.
+	 */
+	public function jsonSerialize(): array {
 		return [
 			'type'   => (string) $this->type,
 			'depth'  => (int) $this->depth,

--- a/ModularContent/PanelCollection.php
+++ b/ModularContent/PanelCollection.php
@@ -83,10 +83,15 @@ class PanelCollection implements \JsonSerializable {
 		return $loop->render();
 	}
 
-	public function jsonSerialize() {
-		return array(
+	/**
+	 * Specify data which should be serialized to JSON.
+	 *
+	 * @return array Always return an array.
+	 */
+	public function jsonSerialize(): array {
+		return [
 			'panels' => $this->panels,
-		);
+		];
 	}
 
 	public function to_json() {

--- a/ModularContent/Sets/Set.php
+++ b/ModularContent/Sets/Set.php
@@ -24,10 +24,10 @@ class Set implements \JsonSerializable {
 	 * Specify data which should be serialized to JSON
 	 *
 	 * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-	 * @return mixed data which can be serialized by <b>json_encode</b>,
+	 * @return array data which can be serialized by <b>json_encode</b>,
 	 * which is a value of any type other than a resource.
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id'          => $this->post_id,
 			'label'       => $this->get_label(),


### PR DESCRIPTION
To help make the code not throw warnings in PHP8 adding return types to the `jsonSerialize()`.